### PR TITLE
chore: log when connection is closed for writing

### DIFF
--- a/lib/broadway_kinesis/log.ex
+++ b/lib/broadway_kinesis/log.ex
@@ -1,0 +1,10 @@
+defmodule BroadwayKinesis.Logger do
+  defmacro __using__(_) do
+    quote do
+      require Logger
+      defp log(message), do: Logger.info("#{__MODULE__}: #{message}")
+      defp warn(message), do: Logger.warning("#{__MODULE__}: #{message}")
+      defp error(message), do: Logger.error("#{__MODULE__}: #{message}")
+    end
+  end
+end

--- a/lib/broadway_kinesis/producer.ex
+++ b/lib/broadway_kinesis/producer.ex
@@ -1,6 +1,7 @@
 defmodule BroadwayKinesis.Producer do
   require BroadwayKinesis.SubscribeToShard
   require ExAws
+  use BroadwayKinesis.Logger
   alias BroadwayKinesis.ProducerRegistry
 
   defmodule State do
@@ -220,10 +221,6 @@ defmodule BroadwayKinesis.Producer do
 
         result
       end
-
-      defp log(message), do: Logger.info("#{__MODULE__}: #{message}")
-      defp warn(message), do: Logger.warning("#{__MODULE__}: #{message}")
-      defp error(message), do: Logger.error("#{__MODULE__}: #{message}")
 
       # Resume position
 

--- a/lib/broadway_kinesis/subscribe_to_shard.ex
+++ b/lib/broadway_kinesis/subscribe_to_shard.ex
@@ -20,6 +20,7 @@ defmodule BroadwayKinesis.SubscribeToShard do
 
   alias Mint.HTTP2
   require Mint.HTTP
+  use BroadwayKinesis.Logger
 
   @content_type "application/x-amz-json-1.1"
   @target_operation "Kinesis_20131202.SubscribeToShard"
@@ -213,6 +214,10 @@ defmodule BroadwayKinesis.SubscribeToShard do
     else
       # Connection is closed for writing; cannot make any more requests (re-request will occur
       # later when we get the final message and see the connection is also closed for reading)
+      log(
+        "event=subscribe_to_shard_connection_closed_for_writing consumer_arn=#{state.consumer_arn}"
+      )
+
       {:ok, state}
     end
   end

--- a/test/broadway_kinesis/producer_test.exs
+++ b/test/broadway_kinesis/producer_test.exs
@@ -1,6 +1,5 @@
 defmodule BroadwayKinesis.ProducerTest do
   use ExUnit.Case
-
   alias BroadwayKinesis.ProducerRegistry
   import ExUnit.CaptureLog
   import Mock

--- a/test/broadway_kinesis/producer_test.exs
+++ b/test/broadway_kinesis/producer_test.exs
@@ -1,5 +1,6 @@
 defmodule BroadwayKinesis.ProducerTest do
   use ExUnit.Case
+
   alias BroadwayKinesis.ProducerRegistry
   import ExUnit.CaptureLog
   import Mock
@@ -17,6 +18,8 @@ defmodule BroadwayKinesis.ProducerTest do
   end
 
   defmodule FakeProducer do
+    use BroadwayKinesis.Logger
+
     use BroadwayKinesis.Producer,
       consumer_arn: "fake_consumer_arn",
       stream_name: "fake_stream_name"


### PR DESCRIPTION
Asana Task: 🐞 [Orbit silently stopped receiving OCS msgs 12/22 1/12](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1212756070175216)

Add logging to match RTR's https://github.com/mbta/rtr/pull/1537, which will hopefully get one of us closer to the root cause.